### PR TITLE
feat(cli): show storage capacity in repo status

### DIFF
--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -56,9 +56,9 @@ type OutputBuffer interface {
 // Capacity describes the storage capacity and usage of a Volume.
 type Capacity struct {
 	// Size of volume in bytes.
-	SizeB uint64
+	SizeB uint64 `json:"capacity"`
 	// Available (writeable) space in bytes.
-	FreeB uint64
+	FreeB uint64 `json:"available"`
 }
 
 // Volume defines disk/volume access API to blob storage.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -50,6 +50,7 @@ type DirectRepository interface {
 	ObjectFormat() object.Format
 	BlobCfg() content.BlobCfgBlob
 	BlobReader() blob.Reader
+	BlobVolume() blob.Volume
 	ContentReader() content.Reader
 	IndexBlobs(ctx context.Context, includeInactive bool) ([]content.IndexBlobInfo, error)
 	Crypter() *content.Crypter
@@ -305,6 +306,11 @@ func (r *directRepository) UniqueID() []byte {
 
 // BlobReader returns the blob reader.
 func (r *directRepository) BlobReader() blob.Reader {
+	return r.blobs
+}
+
+// BlobVolume returns the blob volume interface.
+func (r *directRepository) BlobVolume() blob.Volume {
 	return r.blobs
 }
 


### PR DESCRIPTION
The connected repository's backing storage capacity and available
space can be now retrieved from `kopia repository status`. In text
format, these fields are printed in a human friendly form (MiB, GiB).
In JSON mode (`--json`), the capacity and free space are output
as bytes.